### PR TITLE
Bug/clearcache_logout

### DIFF
--- a/components/NavBar.vue
+++ b/components/NavBar.vue
@@ -245,7 +245,7 @@ export default {
   },
   methods: {
     async logout () {
-      await this.$auth.logout()
+      await this.$utils.logout()
     },
     async countNewNotifications () {
       try {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -128,7 +128,8 @@ export default {
     },
     plugins: [
       { src: '~/plugins/axios.js' },
-      { src: '~/plugins/blockchain.js', mode: 'client' }
+      { src: '~/plugins/blockchain.js', mode: 'client' },
+      { src: '~/plugins/utils.js', mode: 'client' }
     ]
   },
 

--- a/pages/manage/index.vue
+++ b/pages/manage/index.vue
@@ -159,7 +159,7 @@ export default {
       this.taskSectionActive = value
     },
     async logout () {
-      await this.$auth.logout()
+      await this.$utils.logout()
     },
     setPage (newPage) {
       this.page = newPage

--- a/pages/profile/index.vue
+++ b/pages/profile/index.vue
@@ -257,7 +257,7 @@ export default {
   },
   methods: {
     async logout () {
-      await this.$auth.logout()
+      await this.$utils.logout()
     },
     calculatePendingTime (submissionTime) {
       // Here we take the submission  time, add 1 hour, substract time since.

--- a/plugins/axios.js
+++ b/plugins/axios.js
@@ -3,7 +3,7 @@ export default ({ $axios, $auth, app }) => {
     const code = parseInt(error.response && error.response.status)
     if ([401, 403].includes(code) && error.response.data.message.includes('jwt expired')) {
       console.log('refresh token')
-      app.$auth.logout()
+      app.$utils.logout()
     }
 
     return Promise.reject(error)

--- a/plugins/blockchain.js
+++ b/plugins/blockchain.js
@@ -217,7 +217,7 @@ export default (context, inject) => {
         provider.on('disconnect', () => {
           console.log('disconnecting provider') // eslint-disable-line no-console
           this.logout()
-          context.$auth.logout()
+          context.$utils.logout()
         })
 
         // Inform user of account change, only one account can be selected
@@ -226,14 +226,14 @@ export default (context, inject) => {
           if (newWallet.length) {
             if (context.$auth.loggedIn) {
               if (newWallet[0].toLowerCase() !== context.$auth.user.accountName.toLowerCase()) {
-                context.$auth.logout()
+                context.$utils.logout()
               }
             } else {
               this.waitForSignatureFrom = newWallet[0]
             }
           } else {
             this.logout()
-            context.$auth.logout()
+            context.$utils.logout()
           }
         })
 
@@ -246,7 +246,7 @@ export default (context, inject) => {
             alert(`Please switch to the correct chain:\n${this.sdk.config.bscChainName}, Mainnet, chainId: ${this.sdk.config.bscNetworkId}\n\nCurrently on: ${this.bsc.web3.utils.hexToNumberString(_chainId)}\n\nLogging out.`)
             // It is recommended to reload the entire window, or to logout the user to make sure the user doesn't do any txs.
             this.logout()
-            context.$auth.logout() // Logout
+            context.$utils.logout() // Logout
             // window.location.reload() // reload window aswell?
           }
         })

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -1,0 +1,17 @@
+import Vue from 'vue'
+
+export default (context, inject) => {
+  const utils = new Vue({
+    data () {
+      return {
+        stuffHere: null
+      }
+    },
+    computed: {
+    },
+    methods: {
+    }
+  })
+
+  inject('utils', utils)
+}

--- a/plugins/utils.js
+++ b/plugins/utils.js
@@ -10,6 +10,13 @@ export default (context, inject) => {
     computed: {
     },
     methods: {
+      /**
+       * Global logout method
+       */
+      async logout () {
+        context.store.dispatch('qualification/clearAssignedQualifications')
+        await context.$auth.logout()
+      }
     }
   })
 

--- a/store/qualification.js
+++ b/store/qualification.js
@@ -58,6 +58,9 @@ export default {
     },
     SET_ALL_ASSIGNED_QUALIFICATION_LOADED (state, allAssignedQualificationsLoaded) {
       state.allAssignedQualificationsLoaded = allAssignedQualificationsLoaded
+    },
+    CLEAR_ALL_ASSIGNED_QUALIFICATIONS (state) {
+      state.assignedQualifications = []
     }
   },
   getters: {
@@ -181,6 +184,9 @@ export default {
       } catch (e) {
         commit('SET_QUALIFICATION_INFO', { id: qualification.id, info: null })
       }
+    },
+    clearAssignedQualifications ({ commit }) {
+      commit('CLEAR_ALL_ASSIGNED_QUALIFICATIONS')
     }
   },
   state: () => {


### PR DESCRIPTION
BUG:

When users logout and log back in with another account, the assignedQualis from the former account would be loaded from the store.

This pull request creates a new global logout method, and adds the feature to clear the assignedQuali store.

It also sets up the ability to add more features to the logout method in the future. 

Now we also have the `utils` plugins that can be used for other miscellaneous features.